### PR TITLE
Only pass arguments of type uint8_t to the Arduino write function.

### DIFF
--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -31,6 +31,7 @@ jobs:
           - arduino:avr:uno
           - arduino:avr:leonardo
           - arduino:samd:nano_33_iot
+          - arduino:mbed:envie_m7
           - esp8266:esp8266:huzzah:eesz=4M3M,xtal=80
 
         # Specify parameters for each board.
@@ -44,6 +45,8 @@ jobs:
           - arduino-boards-fqbn: arduino:avr:leonardo
           
           - arduino-boards-fqbn: arduino:samd:nano_33_iot
+          
+          - arduino-boards-fqbn: arduino:mbed:envie_m7
 
           - arduino-boards-fqbn: esp8266:esp8266:huzzah:eesz=4M3M,xtal=80
             platform-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json

--- a/examples/DetectTags/DetectTags.ino
+++ b/examples/DetectTags/DetectTags.ino
@@ -22,7 +22,7 @@ RfIntf_t RfInterface;                                              //Intarface t
 
 uint8_t mode = 1;                                                  // modes: 1 = Reader/ Writer, 2 = Emulation
 
-int ResetMode(){                                  //Reset the configuration mode after each reading
+void ResetMode(){                                  //Reset the configuration mode after each reading
   Serial.println("Re-initializing...");
   nfc.ConfigMode(mode);                               
   nfc.StartDiscovery(mode);

--- a/examples/ISO14443-3A_read_block/ISO14443-3A_read_block.ino
+++ b/examples/ISO14443-3A_read_block/ISO14443-3A_read_block.ino
@@ -25,7 +25,7 @@ RfIntf_t RfInterface;                                              //Intarface t
 
 uint8_t mode = 1;                                                  // modes: 1 = Reader/ Writer, 2 = Emulation
 
-int ResetMode(){                                      //Reset the configuration mode after each reading
+void ResetMode(){                                      //Reset the configuration mode after each reading
   Serial.println("Re-initializing...");
   nfc.ConfigMode(mode);                               
   nfc.StartDiscovery(mode);

--- a/examples/ISO14443-3A_write_block/ISO14443-3A_write_block.ino
+++ b/examples/ISO14443-3A_write_block/ISO14443-3A_write_block.ino
@@ -25,7 +25,7 @@ RfIntf_t RfInterface;                                              //Intarface t
 
 uint8_t mode = 1;                                                  // modes: 1 = Reader/ Writer, 2 = Emulation
 
-int ResetMode(){                                      //Reset the configuration mode after each reading
+void ResetMode(){                                      //Reset the configuration mode after each reading
   Serial.println("Re-initializing...");
   nfc.ConfigMode(mode);                               
   nfc.StartDiscovery(mode);

--- a/examples/ISO15693_read_block/ISO15693_read_block.ino
+++ b/examples/ISO15693_read_block/ISO15693_read_block.ino
@@ -25,7 +25,7 @@ RfIntf_t RfInterface;                                              //Intarface t
 
 uint8_t mode = 1;                                                  // modes: 1 = Reader/ Writer, 2 = Emulation
 
-int ResetMode(){                                      //Reset the configuration mode after each reading
+void ResetMode(){                                      //Reset the configuration mode after each reading
   Serial.println("Re-initializing...");
   nfc.ConfigMode(mode);                               
   nfc.StartDiscovery(mode);

--- a/examples/ISO15693_write_block/ISO15693_write_block.ino
+++ b/examples/ISO15693_write_block/ISO15693_write_block.ino
@@ -49,7 +49,7 @@ void setup(){
   Serial.println("Waiting for an ISO15693 Card ...");
 }
 
-int ResetMode(){                                      //Reset the configuration mode after each reading
+void ResetMode(){                                      //Reset the configuration mode after each reading
   Serial.println("Re-initializing...");
   nfc.ConfigMode(mode);                               
   nfc.StartDiscovery(mode);

--- a/examples/MifareClassic_read_block/MifareClassic_read_block.ino
+++ b/examples/MifareClassic_read_block/MifareClassic_read_block.ino
@@ -25,7 +25,7 @@ RfIntf_t RfInterface;                                              //Intarface t
 
 uint8_t mode = 1; 
                                                  // modes: 1 = Reader/ Writer, 2 = Emulation
-int ResetMode(){                                      //Reset the configuration mode after each reading
+void ResetMode(){                                      //Reset the configuration mode after each reading
   Serial.println("Re-initializing...");
   nfc.ConfigMode(mode);                               
   nfc.StartDiscovery(mode);

--- a/examples/MifareClassic_write_block/MifareClassic_write_block.ino
+++ b/examples/MifareClassic_write_block/MifareClassic_write_block.ino
@@ -28,7 +28,7 @@ RfIntf_t RfInterface;                                              //Intarface t
 
 uint8_t mode = 1;                                                  // modes: 1 = Reader/ Writer, 2 = Emulation
 
-int ResetMode(){                                      //Reset the configuration mode after each reading
+void ResetMode(){                                      //Reset the configuration mode after each reading
   Serial.println("Re-initializing...");
   nfc.ConfigMode(mode);                               
   nfc.StartDiscovery(mode);

--- a/examples/P2P_Discovery/P2P_Discovery.ino
+++ b/examples/P2P_Discovery/P2P_Discovery.ino
@@ -22,7 +22,7 @@ RfIntf_t RfInterface;                                              //Intarface t
 
 uint8_t mode = 3;                                                  // modes: 1 = Reader/ Writer, 2 = Emulation, 3 = Peer to peer P2P
 
-int ResetMode(){                                  //Reset the configuration mode after each reading
+void ResetMode(){                                  //Reset the configuration mode after each reading
   Serial.println("Re-initializing...");
   nfc.ConfigMode(mode);                               
   nfc.StartDiscovery(mode);

--- a/src/Electroniccats_PN7150.cpp
+++ b/src/Electroniccats_PN7150.cpp
@@ -78,7 +78,7 @@ uint8_t Electroniccats_PN7150::writeData(uint8_t txBuffer[], uint32_t txBufferLe
 {
     uint32_t nmbrBytesWritten = 0;
     Wire.beginTransmission((uint8_t)_I2Caddress);
-    nmbrBytesWritten = Wire.write(txBuffer, txBufferLevel);
+    nmbrBytesWritten = Wire.write(txBuffer, (int)(txBufferLevel));
     if (nmbrBytesWritten == txBufferLevel)
     {
         byte resultCode;


### PR DESCRIPTION
Only pass arguments of type uint8_t to the Arduino write function.

This fixes a compilation error in the Arduino mbed core, where
Wire.write(uint32_t) is ambiguous

#29 for Portenta