### PR TITLE
Adds support for using any I2C port

### DIFF
--- a/src/Electroniccats_PN7150.cpp
+++ b/src/Electroniccats_PN7150.cpp
@@ -53,18 +53,21 @@ Electroniccats_PN7150::Electroniccats_PN7150(uint8_t IRQpin, uint8_t VENpin,
                 uint8_t I2Caddress, TwoWire *wire) : _IRQpin(IRQpin), _VENpin(VENpin), _I2Caddress(I2Caddress), _wire(wire)
 {
     pinMode(_IRQpin, INPUT);
-    pinMode(_VENpin, OUTPUT);
+    if (_VENpin != 255)
+        pinMode(_VENpin, OUTPUT);
 }
 
 uint8_t Electroniccats_PN7150::begin()
 {
     _wire->begin();
-    digitalWrite(_VENpin, HIGH);
-    delay(1);
-    digitalWrite(_VENpin, LOW);
-    delay(1);
-    digitalWrite(_VENpin, HIGH);
-    delay(3);
+    if (_VENpin != 255) {
+        digitalWrite(_VENpin, HIGH);
+        delay(1);
+        digitalWrite(_VENpin, LOW);
+        delay(1);
+        digitalWrite(_VENpin, HIGH);
+        delay(3);
+    }
     return SUCCESS;
 }
 

--- a/src/Electroniccats_PN7150.h
+++ b/src/Electroniccats_PN7150.h
@@ -2,18 +2,18 @@
 #define Electroniccats_PN7150_H
 /**
  * NXP PN7150 Driver
- * Porting uthors: 
+ * Porting uthors:
  *        Salvador Mendoza - @Netxing - salmg.net
  *        Andres Sabas - Electronic Cats - Electroniccats.com
  *
  *  November 2020
- * 
- * This code is beerware; if you see me (or any other collaborator 
- * member) at the local, and you've found our code helpful, 
+ *
+ * This code is beerware; if you see me (or any other collaborator
+ * member) at the local, and you've found our code helpful,
  * please buy us a round!
  * Distributed as-is; no warranty is given.
  *
- * A few methods and ideas were extract from 
+ * A few methods and ideas were extract from
  * https://github.com/Strooom/PN7150
  *
  */
@@ -27,11 +27,6 @@
 #include <i2c_t3.h>                           // Credits Brian "nox771" : see https://forum.pjrc.com/threads/21680-New-I2C-library-for-Teensy3
 #else
 #include <Wire.h>
-#if defined(__AVR__) || defined(__i386__) || defined(ARDUINO_ARCH_SAMD) || defined(ESP8266) || defined(ARDUINO_ARCH_STM32)
-#define WIRE Wire
-#else // Arduino Due
-#define WIRE Wire1
-#endif // TODO :   i2c_t3.h ensures a maximum I2C message of 259, which is sufficient. Other I2C implementations have shorter buffers (32 bytes)
 #endif
 
 /* Following definitions specifies which settings will apply when NxpNci_ConfigureSettings()
@@ -250,6 +245,7 @@ class Electroniccats_PN7150
 {
 private:
     uint8_t _IRQpin, _VENpin, _I2Caddress;
+    TwoWire *_wire;
     uint8_t rxBuffer[MaxPayloadSize + MsgHeaderSize]; // buffer where we store bytes received until they form a complete message
     void setTimeOut(unsigned long);                   // set a timeOut for an expected next event, eg reception of Response after sending a Command
     bool isTimeOut() const;
@@ -261,7 +257,7 @@ private:
     uint8_t gNfcController_fw_version[3] = {0};
 
 public:
-    Electroniccats_PN7150(uint8_t IRQpin, uint8_t VENpin, uint8_t I2Caddress);
+    Electroniccats_PN7150(uint8_t IRQpin, uint8_t VENpin, uint8_t I2Caddress, TwoWire *wire = &Wire);
     int GetFwVersion();
     uint8_t begin(void);
     uint8_t writeData(uint8_t data[], uint32_t dataLength) const; // write data from DeviceHost to PN7150. Returns success (0) or Fail (> 0)

--- a/src/Electroniccats_PN7150.h
+++ b/src/Electroniccats_PN7150.h
@@ -29,6 +29,7 @@
 #include <Wire.h>
 #endif
 
+#define NO_PN7150_RESET_PIN 255
 /* Following definitions specifies which settings will apply when NxpNci_ConfigureSettings()
  * API is called from the application
  */


### PR DESCRIPTION
This PR adds support to the library for using an arbitrary TwoWire port and removes the unused WIRE definition.